### PR TITLE
Add token management support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,3 +10,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Configuration for Auth0's domain, client ID and secret
+- Token management with refresh support when expired or almost expiring

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,6 +3,7 @@ PATH
   specs:
     http-auth0 (0.1.0)
       dry-configurable (~> 0.14)
+      jwt (~> 2.3.0)
 
 GEM
   remote: https://rubygems.org/
@@ -25,6 +26,7 @@ GEM
       ruby2_keywords (>= 0.0.4)
     faraday-net_http (2.0.1)
     hashdiff (1.0.1)
+    jwt (2.3.0)
     multipart-parser (0.1.1)
     parallel (1.21.0)
     parser (3.1.0.0)
@@ -73,6 +75,7 @@ GEM
       docile (~> 1.1)
       simplecov-html (~> 0.11)
     simplecov-html (0.12.3)
+    timecop (0.9.4)
     unicode-display_width (2.1.0)
     webmock (3.14.0)
       addressable (>= 2.8.0)
@@ -94,6 +97,7 @@ DEPENDENCIES
   rubocop-rspec
   rubocop-shopify (~> 2.4.0)
   simplecov (~> 0.19.0)
+  timecop (~> 0.9.4)
   webmock (~> 3.4)
 
 BUNDLED WITH

--- a/http-auth0.gemspec
+++ b/http-auth0.gemspec
@@ -28,6 +28,7 @@ Gem::Specification.new do |s|
   s.extra_rdoc_files = ["LICENSE", "README.md"]
 
   s.add_dependency("dry-configurable", "~> 0.14")
+  s.add_dependency("jwt", "~> 2.3.0")
 
   s.add_development_dependency("faraday", "~> 2.0")
 
@@ -39,6 +40,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency("rubocop-rspec")
   s.add_development_dependency("rubocop-shopify", "~> 2.4.0")
   s.add_development_dependency("simplecov", "~> 0.19.0")
+  s.add_development_dependency("timecop", "~> 0.9.4")
 
   s.add_development_dependency("multipart-parser", "~> 0.1.1")
   s.add_development_dependency("webmock", "~> 3.4")

--- a/lib/http/auth0.rb
+++ b/lib/http/auth0.rb
@@ -10,7 +10,8 @@ module HTTP
     setting(:client_id)
     setting(:client_secret)
     setting(:domain)
-    setting(:seconds_before_refresh, 60)
+    setting(:logger, default: Logger.new(STDOUT))
+    setting(:seconds_before_refresh, default: 60)
   end
 end
 

--- a/lib/http/auth0.rb
+++ b/lib/http/auth0.rb
@@ -4,11 +4,28 @@ require "dry/configurable"
 
 module HTTP
   class Auth0
+    class ConfigurationError < StandardError; end
+
     extend(Dry::Configurable)
 
     setting(:client_id)
     setting(:client_secret)
     setting(:domain)
+
+    class << self
+      def token(aud:)
+        validate_configuration(key: :client_id)
+        validate_configuration(key: :client_secret)
+
+        "IMPLEMENT_ME"
+      end
+
+      private
+
+      def validate_configuration(key:)
+        raise ConfigurationError, "Missing #{key} in configuration" if [nil, ""].any?(config.send(key))
+      end
+    end
   end
 end
 

--- a/lib/http/auth0.rb
+++ b/lib/http/auth0.rb
@@ -1,31 +1,15 @@
 # frozen_string_literal: true
 
 require "dry/configurable"
+require_relative "auth0/token"
 
 module HTTP
   class Auth0
-    class ConfigurationError < StandardError; end
-
     extend(Dry::Configurable)
 
     setting(:client_id)
     setting(:client_secret)
     setting(:domain)
-
-    class << self
-      def token(aud:)
-        validate_configuration(key: :client_id)
-        validate_configuration(key: :client_secret)
-
-        "IMPLEMENT_ME"
-      end
-
-      private
-
-      def validate_configuration(key:)
-        raise ConfigurationError, "Missing #{key} in configuration" if [nil, ""].any?(config.send(key))
-      end
-    end
   end
 end
 

--- a/lib/http/auth0.rb
+++ b/lib/http/auth0.rb
@@ -10,6 +10,7 @@ module HTTP
     setting(:client_id)
     setting(:client_secret)
     setting(:domain)
+    setting(:seconds_before_refresh, 60)
   end
 end
 

--- a/lib/http/auth0/token.rb
+++ b/lib/http/auth0/token.rb
@@ -49,7 +49,7 @@ module HTTP
         url = URI("https://#{config.domain}/oauth/token")
         http = Net::HTTP.new(url.host, url.port)
         http.use_ssl = true
-        http.verify_mode = OpenSSL::SSL::VERIFY_NONE
+        http.verify_mode = OpenSSL::SSL::VERIFY_PEER
 
         request = Net::HTTP::Post.new(url)
         request["content-type"] = "application/x-www-form-urlencoded"

--- a/lib/http/auth0/token.rb
+++ b/lib/http/auth0/token.rb
@@ -36,7 +36,8 @@ module HTTP
         payload = decoded_token.first
         expiration = payload["exp"]
         current_time = Time.now.to_i
-        expiration_time = Time.at(expiration).to_i
+        seconds_before_refresh = config.seconds_before_refresh
+        expiration_time = Time.at(expiration).to_i - seconds_before_refresh.to_i
 
         current_time >= expiration_time
       rescue StandardError => _e

--- a/lib/http/auth0/token.rb
+++ b/lib/http/auth0/token.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+require "uri"
+require "net/http"
+require "openssl"
+require "json"
+
+module HTTP
+  class Auth0
+    class ConfigurationError < StandardError; end
+
+    class << self
+      def token(aud:)
+        validate_configuration(key: :client_id)
+        validate_configuration(key: :client_secret)
+
+        request_access_token(aud: aud)
+      end
+
+      private
+
+      attr_accessor :access_token
+
+      def validate_configuration(key:)
+        raise ConfigurationError, "Missing #{key} in configuration" if [nil, ""].any?(config.send(key))
+      end
+
+      def request_access_token(aud:)
+        url = URI("https://#{config.domain}/oauth/token")
+        http = Net::HTTP.new(url.host, url.port)
+        http.use_ssl = true
+        http.verify_mode = OpenSSL::SSL::VERIFY_NONE
+
+        request = Net::HTTP::Post.new(url)
+        request["content-type"] = "application/x-www-form-urlencoded"
+
+        body = request_body(aud: aud)
+        request.body = body.map { |key, value| "#{key}=#{value}" }.join("&")
+
+        response = http.request(request)
+        body = response.read_body
+        auth0_response = JSON.parse(body)
+        @access_token = auth0_response["access_token"]
+        puts "body: #{body}"
+        puts "auth0_response: #{auth0_response}"
+        puts "access_token: #{access_token}"
+
+        access_token
+      end
+
+      def request_body(aud:)
+        {
+          grant_type: "client_credentials",
+          client_id: config.client_id,
+          client_secret: config.client_secret,
+          audience: aud,
+        }
+      end
+    end
+  end
+end

--- a/lib/http/auth0/token.rb
+++ b/lib/http/auth0/token.rb
@@ -58,16 +58,16 @@ module HTTP
         request.body = body.map { |key, value| "#{key}=#{value}" }.join("&")
 
         response = http.request(request)
+        body = response.read_body
 
         case response
         when Net::HTTPSuccess
-          body = response.read_body
           auth0_response = JSON.parse(body)
           auth0_response["access_token"].tap do |access_token|
             access_tokens[aud] = access_token
           end
         else
-          config.logger.warn(response.message)
+          config.logger.warn("#{response.message}: #{body}")
           nil
         end
       end

--- a/lib/http/auth0/token.rb
+++ b/lib/http/auth0/token.rb
@@ -40,8 +40,8 @@ module HTTP
         expiration_time = Time.at(expiration).to_i - seconds_before_refresh.to_i
 
         current_time >= expiration_time
-      rescue StandardError => _e
-        # TODO: Log that token cannot be decoded
+      rescue StandardError => e
+        config.logger.error(e)
         true
       end
 
@@ -66,6 +66,9 @@ module HTTP
           auth0_response["access_token"].tap do |access_token|
             access_tokens[aud] = access_token
           end
+        else
+          config.logger.warn(response.message)
+          nil
         end
       end
 

--- a/spec/http/auth0/token_spec.rb
+++ b/spec/http/auth0/token_spec.rb
@@ -1,0 +1,85 @@
+# frozen_string_literal: true
+
+RSpec.describe("HTTP::Auth0") do
+  subject(:described_class) { HTTP::Auth0 }
+  let(:client_id)     { "CLIENT_ID" }
+  let(:client_secret) { "CLIENT_SECRET" }
+  let(:domain)        { "firstcircle.ph" }
+
+  before { described_class.reset_config }
+
+  describe ".token(aud:)" do
+    let(:aud) { "https://api.firstcircle.ph" }
+
+    before do
+      described_class.config.client_id      = client_id
+      described_class.config.client_secret  = client_secret
+      described_class.config.domain         = domain
+    end
+
+    context "when client_id is nil" do
+      before { described_class.config.client_id = nil }
+
+      it do
+        expect { described_class.token(aud: aud) }.to(raise_error(
+          an_instance_of(HTTP::Auth0::ConfigurationError)
+            .and(having_attributes(message: "Missing client_id in configuration"))
+        ))
+      end
+    end
+
+    context "when client_secret is nil" do
+      before { described_class.config.client_secret = nil }
+
+      it do
+        expect { described_class.token(aud: aud) }.to(raise_error(
+          an_instance_of(HTTP::Auth0::ConfigurationError)
+            .and(having_attributes(message: "Missing client_secret in configuration"))
+        ))
+      end
+    end
+
+    context "when client id and secret are provided" do
+      let(:access_token) do
+        "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCIsImtpZCI6ImRKbzFsM3owOEo0REUyVWQ3R"\
+          "HJybiJ9.eyJpc3MiOiJodHRwczovL2Rldi1xNGg1dnhnbS5qcC5hdXRoMC5jb20vIiwic"\
+          "3ViIjoiUWVFR292OURSSjNjTnhGOFNZdXkwMUhnM1JlSHRQeDlAY2xpZW50cyIsImF1ZC"\
+          "I6Imh0dHBzOi8vc3RhZ2luZy0wMS5hcGkuY29ubmVjdC5teS5maXJzdGNpcmNsZS5waC9"\
+          "ncmFwaHFsIiwiaWF0IjoxNjQzODgxMjU1LCJleHAiOjE2NDM5Njc2NTUsImF6cCI6IlFl"\
+          "RUdvdjlEUkozY054RjhTWXV5MDFIZzNSZUh0UHg5IiwiZ3R5IjoiY2xpZW50LWNyZWRlb"\
+          "nRpYWxzIiwicGVybWlzc2lvbnMiOltdfQ.gQ62J6XAEw2g-ROgImooWLmYLZwzRHd2S6O"\
+          "1fMM3MIui30qExQ8ZFD9eAcVDzfb6PFBYsyEBsK_dM6htYiE36jUYNHRy7_I1uFAYLpBb"\
+          "_gNmgSUNHZkoZCzSnlD7GS-qojFy1Zyq3vCxD_qbCNqz0NlI1t7s-OIBN2gF3w9mwSUWt"\
+          "JU04KLdSyWU3r928vAHlkYwgDnfNUzPqljOJueZs3gMTdKYR1V_72dycgs_DtqGyCtTd_"\
+          "wEN1q_RALEPeCqQQ9YMZA5cW5x6HXy2YTbWJLNGj5n4yxJzeDhGsDLw9GgWc9WYAIT6Bv"\
+          "b-Z9qdiCHCcOY_16y1h8iCESDfRKX4A"
+      end
+
+      before do
+        stub_request(:post, "https://firstcircle.ph/oauth/token")
+          .with(
+            body: {
+              "audience" => "https://api.firstcircle.ph",
+              "client_id" => "CLIENT_ID",
+              "client_secret" => "CLIENT_SECRET",
+              "grant_type" => "client_credentials",
+            },
+            headers: {
+              "Accept" => "*/*",
+              "Accept-Encoding" => "gzip;q=1.0,deflate;q=0.6,identity;q=0.3",
+              "Content-Type" => "application/x-www-form-urlencoded",
+              "Host" => "firstcircle.ph",
+              "User-Agent" => "Ruby",
+            }
+          )
+          .to_return(
+            status: 200,
+            body: "{\"access_token\":\"#{access_token}\",\"expires_in\":86400,\"token_type\":\"Bearer\"}",
+            headers: {}
+          )
+      end
+
+      it { expect(described_class.token(aud: aud)).to(eq(access_token)) }
+    end
+  end
+end

--- a/spec/http/auth0/token_spec.rb
+++ b/spec/http/auth0/token_spec.rb
@@ -103,6 +103,15 @@ RSpec.describe("HTTP::Auth0") do
         # rubocop:enable RSpec/MessageSpies, RSpec/SubjectStub
         described_class.token(aud: aud)
       end
+
+      it "requests for a new access token when it's expiring relative to seconds_before_refresh" do
+        described_class.token(aud: aud)
+        Timecop.freeze(Time.at(1643967655 - 60))
+        # rubocop:disable RSpec/MessageSpies, RSpec/SubjectStub
+        expect(described_class).to(receive(:request_access_token))
+        # rubocop:enable RSpec/MessageSpies, RSpec/SubjectStub
+        described_class.token(aud: aud)
+      end
     end
   end
 end

--- a/spec/http/auth0/token_spec.rb
+++ b/spec/http/auth0/token_spec.rb
@@ -2,6 +2,7 @@
 
 RSpec.describe("HTTP::Auth0") do
   subject(:described_class) { HTTP::Auth0 }
+
   let(:client_id)     { "CLIENT_ID" }
   let(:client_secret) { "CLIENT_SECRET" }
   let(:domain)        { "firstcircle.ph" }
@@ -80,6 +81,14 @@ RSpec.describe("HTTP::Auth0") do
       end
 
       it { expect(described_class.token(aud: aud)).to(eq(access_token)) }
+
+      it "does not send multiple request for access token when it got one" do
+        described_class.token(aud: aud)
+        # rubocop:disable RSpec/MessageSpies, RSpec/SubjectStub
+        expect(described_class).not_to(receive(:request_access_token))
+        # rubocop:enable RSpec/MessageSpies, RSpec/SubjectStub
+        described_class.token(aud: aud)
+      end
     end
   end
 end

--- a/spec/http/auth0_spec.rb
+++ b/spec/http/auth0_spec.rb
@@ -5,6 +5,8 @@ RSpec.describe(HTTP::Auth0) do
   let(:client_secret) { "CLIENT_SECRET" }
   let(:domain)        { "firstcircle.ph" }
 
+  before { described_class.reset_config }
+
   it "has a version number" do
     expect(HTTP::Auth0::VERSION).to(be_a(String))
   end
@@ -36,6 +38,42 @@ RSpec.describe(HTTP::Auth0) do
       it { expect(described_class.config.client_id).to(eq(client_id)) }
       it { expect(described_class.config.client_secret).to(eq(client_secret)) }
       it { expect(described_class.config.domain).to(eq(domain)) }
+    end
+  end
+
+  describe ".token(aud:)" do
+    let(:aud) { "https://api.firstcircle.ph" }
+
+    before do
+      described_class.config.client_id      = client_id
+      described_class.config.client_secret  = client_secret
+      described_class.config.domain         = domain
+    end
+
+    context "when client_id is nil" do
+      before { described_class.config.client_id = nil }
+
+      it do
+        expect { described_class.token(aud: aud) }.to(raise_error(
+          an_instance_of(HTTP::Auth0::ConfigurationError)
+            .and(having_attributes(message: "Missing client_id in configuration"))
+        ))
+      end
+    end
+
+    context "when client_secret is nil" do
+      before { described_class.config.client_secret = nil }
+
+      it do
+        expect { described_class.token(aud: aud) }.to(raise_error(
+          an_instance_of(HTTP::Auth0::ConfigurationError)
+            .and(having_attributes(message: "Missing client_secret in configuration"))
+        ))
+      end
+    end
+
+    context "when client id and secret are provided" do
+      it { expect(described_class.token(aud: aud)).to(eq("IMPLEMENT_ME")) }
     end
   end
 end

--- a/spec/http/auth0_spec.rb
+++ b/spec/http/auth0_spec.rb
@@ -24,6 +24,7 @@ RSpec.describe(HTTP::Auth0) do
       it { expect(described_class.config.client_id).to(eq(client_id)) }
       it { expect(described_class.config.client_secret).to(eq(client_secret)) }
       it { expect(described_class.config.domain).to(eq(domain)) }
+      it { expect(described_class.config.logger).to(be_an_instance_of(Logger)) }
       it { expect(described_class.config.seconds_before_refresh).to(eq(60)) }
     end
   end
@@ -39,6 +40,7 @@ RSpec.describe(HTTP::Auth0) do
       it { expect(described_class.config.client_id).to(eq(client_id)) }
       it { expect(described_class.config.client_secret).to(eq(client_secret)) }
       it { expect(described_class.config.domain).to(eq(domain)) }
+      it { expect(described_class.config.logger).to(be_an_instance_of(Logger)) }
       it { expect(described_class.config.seconds_before_refresh).to(eq(60)) }
     end
   end

--- a/spec/http/auth0_spec.rb
+++ b/spec/http/auth0_spec.rb
@@ -40,40 +40,4 @@ RSpec.describe(HTTP::Auth0) do
       it { expect(described_class.config.domain).to(eq(domain)) }
     end
   end
-
-  describe ".token(aud:)" do
-    let(:aud) { "https://api.firstcircle.ph" }
-
-    before do
-      described_class.config.client_id      = client_id
-      described_class.config.client_secret  = client_secret
-      described_class.config.domain         = domain
-    end
-
-    context "when client_id is nil" do
-      before { described_class.config.client_id = nil }
-
-      it do
-        expect { described_class.token(aud: aud) }.to(raise_error(
-          an_instance_of(HTTP::Auth0::ConfigurationError)
-            .and(having_attributes(message: "Missing client_id in configuration"))
-        ))
-      end
-    end
-
-    context "when client_secret is nil" do
-      before { described_class.config.client_secret = nil }
-
-      it do
-        expect { described_class.token(aud: aud) }.to(raise_error(
-          an_instance_of(HTTP::Auth0::ConfigurationError)
-            .and(having_attributes(message: "Missing client_secret in configuration"))
-        ))
-      end
-    end
-
-    context "when client id and secret are provided" do
-      it { expect(described_class.token(aud: aud)).to(eq("IMPLEMENT_ME")) }
-    end
-  end
 end

--- a/spec/http/auth0_spec.rb
+++ b/spec/http/auth0_spec.rb
@@ -24,6 +24,7 @@ RSpec.describe(HTTP::Auth0) do
       it { expect(described_class.config.client_id).to(eq(client_id)) }
       it { expect(described_class.config.client_secret).to(eq(client_secret)) }
       it { expect(described_class.config.domain).to(eq(domain)) }
+      it { expect(described_class.config.seconds_before_refresh).to(eq(60)) }
     end
   end
 
@@ -38,6 +39,7 @@ RSpec.describe(HTTP::Auth0) do
       it { expect(described_class.config.client_id).to(eq(client_id)) }
       it { expect(described_class.config.client_secret).to(eq(client_secret)) }
       it { expect(described_class.config.domain).to(eq(domain)) }
+      it { expect(described_class.config.seconds_before_refresh).to(eq(60)) }
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -6,6 +6,7 @@ require "http/auth0"
 require "faraday_specs_setup"
 require "simplecov"
 require "dry/configurable/test_interface"
+require "timecop"
 
 SimpleCov.start do
   add_filter "/spec/"

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -5,11 +5,18 @@ require "http/auth0"
 # This is the magic bit. It requires a tests suite from the Faraday gem that you can run against your adapter
 require "faraday_specs_setup"
 require "simplecov"
+require "dry/configurable/test_interface"
 
 SimpleCov.start do
   add_filter "/spec/"
   minimum_coverage 95
   minimum_coverage_by_file 90
+end
+
+module HTTP
+  class Auth0
+    enable_test_interface
+  end
 end
 
 RSpec.configure do |config|


### PR DESCRIPTION
### Changes

- Expose `Auth0.token(aud:)` that will allow clients to seamlessly fetch an access token from Auth0 for a given `aud`.
- Cache access token until the `exp` set in its payload, with a default option of 60 seconds that can be set through `seconds_before_refresh` which will refresh the access token 60 seconds earlier than the expiration.
- Add configurable logger that will print debug and error messages for when HTTP request for access token is not successful or when JWT cannot be decoded.
- Add runtime dependency on [ruby-jwt](https://github.com/jwt/ruby-jwt) so we can easily decode the access token coming from Auth0.

### References
- [Token management section for Auth app using Auth0 RFC](https://github.com/carabao-capital/rfcs/blob/179477630-auth0/text/0000-app-auth.md#token-management)

### Testing

```
➜ irb
irb(main):001:0> require 'http/auth0'
=> true
irb(main):002:1* HTTP::Auth0.configure do |auth0|
irb(main):003:1*   auth0.domain = 'dev-q4h5vxgm.jp.auth0.com'
irb(main):004:1*   auth0.client_id = 'QeEGov9DRJ3cNxF8SYuy01Hg3ReHtPx9'
irb(main):005:1*   auth0.client_secret = 'd9gub4d3WpBdrORFh_NdSEmeQDaFWjXKfpR-wgld16TEOwsCBCCr457Uo0QJ3wBY'
irb(main):006:0> end
=> HTTP::Auth0
irb(main):007:0> HTTP::Auth0.token(aud: "https://staging-01.api.connect.my.firstcircle.ph/graphql")
=> "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCIsImtpZCI6ImRKbzFsM3owOEo0REUyVWQ3RHJybiJ9.eyJpc3MiOiJodHRwczovL2Rldi1xNGg1dnhnbS5qcC5hdXRoMC5jb20vIiwic3ViIjoiUWVFR292OURSSjNjTnhGOFNZdXkwMUhnM1JlSHRQeDlAY2xpZW50cyIsImF1ZCI6Imh0dHBzOi8vc3RhZ2luZy0wMS5hcGkuY29ubmVjdC5teS5maXJzdGNpcmNsZS5waC9ncmFwaHFsIiwiaWF0IjoxNjQ0MTk4OTY2LCJleHAiOjE2NDQyODUzNjYsImF6cCI6IlFlRUdvdjlEUkozY054RjhTWXV5MDFIZzNSZUh0UHg5IiwiZ3R5IjoiY2xpZW50LWNyZWRlbnRpYWxzIiwicGVybWlzc2lvbnMiOltdfQ.JlYkB2KCkW_7KwS9ACYJDOHdFMXRypUtNOkMDgxpZ9oPYX0e3icwMfs_VI-7omJ9nwqR-YWQWBGJELETu3Aawd7hoCsCU-LFm4RxvaQoT36Xxor2YFfxnLKPEGhy4ee4zYcUZYrOoer_UvVJIcDw0LEVBZBFovvKTL6duCdB1k0wW7r34iTfJzR2f7iiRg9cJkTU941YuoqFfiONhClWVifjbQkmTbWbInxXRCcgYDqUHE0Xsl7yAEzQhu-jYNZyjBibD6wzuKoK235v66PJlhnUW5WE6_8Tjywk6Ms-KBaVZj6D3sVedOL-J4zRzWJOtATUzBLuFAw_J2jh8CTh7Q"

```

* [x] This change adds unit test coverage
* [x] This change has been tested on the latest version of Ruby (3.1.0)

### Checklist

* [x] All existing and new tests complete without errors
* [x] Rubocop passes on all added/modified files
* [x] All active GitHub checks have passed

