### PR TITLE
Add support for Faraday's request middleware

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,3 +11,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Configuration for Auth0's domain, client ID and secret
 - Token management with refresh support when expired or almost expiring
+- Faraday request middleware support

--- a/README.md
+++ b/README.md
@@ -1,1 +1,77 @@
-# HTTP Auth0
+# http-auth0
+
+[![CI](https://github.com/carabao-capital/http-auth0/actions/workflows/ci.yaml/badge.svg)](https://github.com/carabao-capital/http-auth0/actions/workflows/ci.yaml)
+
+HTTP abstraction layer for Auth application [RFC](https://github.com/carabao-capital/rfcs/pull/2)
+
+## Installation
+
+Add these lines to your application's Gemfile:
+
+```ruby
+source 'https://rubygems.pkg.github.com/carabao-capital' do
+  gem 'http-auth0'
+end
+```
+
+And then execute:
+
+    $ bundle
+
+## Usage
+
+### Configure the gem in an initializer
+
+```ruby
+HTTP::Auth0.configure do |auth0|
+  auth0.domain = 'insert-domain-here.jp.auth0.com'
+  auth0.client_id = 'insert-client-id-here'
+  auth0.client_secret = 'insert-client-secret-here'
+end
+```
+
+### Use with your preferred HTTP client
+### Faraday Example
+
+```ruby
+require 'faraday'
+require 'faraday/net_http'
+require 'http/auth0/middleware'
+
+conn = Faraday.new do |f|
+  f.use HTTP::Auth0::Middleware
+end
+
+conn.post("https://staging-01.api.connect.my.firstcircle.ph/graphql")
+```
+
+### Net::HTTP Example
+
+```ruby
+require 'http/auth0'
+require 'net/http'    
+
+uri = URI("https://staging-01.api.connect.my.firstcircle.ph/graphql")
+req = Net::HTTP::Get.new(uri)
+req['Authorization'] = HTTP::Auth0.token(aud: uri.to_s)
+
+res = Net::HTTP.start(uri.hostname, uri.port) do |http|
+  http.request(req)
+end
+
+puts res.body
+```
+
+## Dependencies
+
+- [Auth0](https://auth0.com/)
+- [dry-configurable](https://github.com/dry-rb/dry-configurable)
+- [ruby-jwt](https://github.com/jwt/ruby-jwt)
+
+## Contributing
+
+1. Clone the [http-auth0 repo](https://github.com/carabao-capital/http-auth0)
+2. Create your feature branch (`git checkout -b my-new-feature`)
+3. Commit your changes (`git commit -am 'Add some feature'`)
+4. Push to the branch (`git push origin my-new-feature`)
+5. Create a new Pull Request

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![CI](https://github.com/carabao-capital/http-auth0/actions/workflows/ci.yaml/badge.svg)](https://github.com/carabao-capital/http-auth0/actions/workflows/ci.yaml)
 
-HTTP abstraction layer for Auth application [RFC](https://github.com/carabao-capital/rfcs/pull/2)
+HTTP client abstraction layer for Auth Application [RFC](https://github.com/carabao-capital/rfcs/pull/2)
 
 ## Installation
 
@@ -15,8 +15,9 @@ end
 ```
 
 And then execute:
-
-    $ bundle
+```bash
+$ bundle
+```
 
 ## Usage
 
@@ -31,7 +32,7 @@ end
 ```
 
 ### Use with your preferred HTTP client
-### Faraday Example
+#### Faraday Example
 
 ```ruby
 require 'faraday'
@@ -45,7 +46,7 @@ end
 conn.post("https://staging-01.api.connect.my.firstcircle.ph/graphql")
 ```
 
-### Net::HTTP Example
+#### Net::HTTP Example
 
 ```ruby
 require 'http/auth0'

--- a/lib/http/auth0/middleware.rb
+++ b/lib/http/auth0/middleware.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "faraday"
+require "http/auth0"
 
 module HTTP
   class Auth0

--- a/lib/http/auth0/middleware.rb
+++ b/lib/http/auth0/middleware.rb
@@ -25,6 +25,10 @@ module HTTP
       # @param env [Faraday::Env]
       # @return [String] a header value
       def auth0_token(env)
+        uri = env.url.to_s
+        aud_uri = URI.parse(uri)
+        aud_uri.fragment = aud_uri.query = nil
+        Auth0.token(aud: aud_uri.to_s)
       end
     end
   end

--- a/lib/http/auth0/middleware.rb
+++ b/lib/http/auth0/middleware.rb
@@ -17,7 +17,7 @@ module HTTP
       def on_request(env)
         return if env.request_headers[KEY]
 
-        env.request_headers[KEY] = auth0_token(env)
+        env.request_headers[KEY] = "Bearer #{auth0_token(env)}"
       end
 
       private

--- a/spec/http/auth0/middleware_spec.rb
+++ b/spec/http/auth0/middleware_spec.rb
@@ -2,20 +2,82 @@
 
 require "http/auth0/middleware"
 
-# TODO: Replace with actual spec when middleware feature comes in as
-# these are just to appease Simplecov
 RSpec.describe(HTTP::Auth0::Middleware) do
+  let(:auth0) { HTTP::Auth0 }
+
   describe "#on_request(env)" do
     let(:app) { instance_double("app") }
     let(:middleware) { described_class.new(app) }
-    let(:request_headers) { { Authorization: "ALREADY_SET" } }
 
-    it do
-      expect(
-        middleware.on_request(
-          Struct.new(:request_headers).new(request_headers: request_headers)
+    context "when Authorization header is set" do
+      let(:request_headers) { { "Authorization" => "ALREADY_SET" } }
+
+      it do
+        expect(
+          middleware.on_request(
+            Struct.new(:request_headers).new(request_headers)
+          )
+        ).to(be_nil)
+      end
+    end
+
+    context "when Authorization header is not set" do
+      let(:access_token) do
+        "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCIsImtpZCI6ImRKbzFsM3owOEo0REUyVWQ3R"\
+          "HJybiJ9.eyJpc3MiOiJodHRwczovL2Rldi1xNGg1dnhnbS5qcC5hdXRoMC5jb20vIiwic"\
+          "3ViIjoiUWVFR292OURSSjNjTnhGOFNZdXkwMUhnM1JlSHRQeDlAY2xpZW50cyIsImF1ZC"\
+          "I6Imh0dHBzOi8vc3RhZ2luZy0wMS5hcGkuY29ubmVjdC5teS5maXJzdGNpcmNsZS5waC9"\
+          "ncmFwaHFsIiwiaWF0IjoxNjQzODgxMjU1LCJleHAiOjE2NDM5Njc2NTUsImF6cCI6IlFl"\
+          "RUdvdjlEUkozY054RjhTWXV5MDFIZzNSZUh0UHg5IiwiZ3R5IjoiY2xpZW50LWNyZWRlb"\
+          "nRpYWxzIiwicGVybWlzc2lvbnMiOltdfQ.gQ62J6XAEw2g-ROgImooWLmYLZwzRHd2S6O"\
+          "1fMM3MIui30qExQ8ZFD9eAcVDzfb6PFBYsyEBsK_dM6htYiE36jUYNHRy7_I1uFAYLpBb"\
+          "_gNmgSUNHZkoZCzSnlD7GS-qojFy1Zyq3vCxD_qbCNqz0NlI1t7s-OIBN2gF3w9mwSUWt"\
+          "JU04KLdSyWU3r928vAHlkYwgDnfNUzPqljOJueZs3gMTdKYR1V_72dycgs_DtqGyCtTd_"\
+          "wEN1q_RALEPeCqQQ9YMZA5cW5x6HXy2YTbWJLNGj5n4yxJzeDhGsDLw9GgWc9WYAIT6Bv"\
+          "b-Z9qdiCHCcOY_16y1h8iCESDfRKX4A"
+      end
+      let(:env) do
+        Struct.new(:request_headers, :url).new(
+          {},
+          URI("https://api.firstcircle.ph")
         )
-      ).to(be_nil)
+      end
+
+      before do
+        auth0.config.client_id      = "CLIENT_ID"
+        auth0.config.client_secret  = "CLIENT_SECRET"
+        auth0.config.domain         = "firstcircle.ph"
+
+        Timecop.freeze(Time.at(1643881255))
+        stub_request(:post, "https://firstcircle.ph/oauth/token")
+          .with(
+            body: {
+              "audience" => "https://api.firstcircle.ph",
+              "client_id" => "CLIENT_ID",
+              "client_secret" => "CLIENT_SECRET",
+              "grant_type" => "client_credentials",
+            },
+            headers: {
+              "Accept" => "*/*",
+              "Accept-Encoding" => "gzip;q=1.0,deflate;q=0.6,identity;q=0.3",
+              "Content-Type" => "application/x-www-form-urlencoded",
+              "Host" => "firstcircle.ph",
+              "User-Agent" => "Ruby",
+            }
+          )
+          .to_return(
+            status: 200,
+            body: "{\"access_token\":\"#{access_token}\",\"expires_in\":86400,\"token_type\":\"Bearer\"}",
+            headers: {}
+          )
+      end
+
+      it { expect(middleware.on_request(env)).not_to(be_nil) }
+
+      it do
+        middleware.on_request(env)
+        expect(env.request_headers["Authorization"]).to(eq(access_token))
+      end
     end
   end
 end

--- a/spec/http/auth0/middleware_spec.rb
+++ b/spec/http/auth0/middleware_spec.rb
@@ -76,7 +76,7 @@ RSpec.describe(HTTP::Auth0::Middleware) do
 
       it do
         middleware.on_request(env)
-        expect(env.request_headers["Authorization"]).to(eq(access_token))
+        expect(env.request_headers["Authorization"]).to(eq("Bearer #{access_token}"))
       end
     end
   end


### PR DESCRIPTION
### Changes

- Add support for faraday's request middleware
- Add instructions for using the gem to README

### References

- [Faraday](https://github.com/lostisland/faraday)
- [Comparison of Ruby HTTP clients](https://www.scrapingbee.com/blog/best-ruby-http-clients/#faraday)

### Testing

```➜ irb
irb(main):001:0> require 'faraday'
irb(main):002:0> require 'faraday/net_http'
irb(main):003:0> require 'http/auth0/middleware'
=> true
irb(main):004:1* conn = Faraday.new do |f|
irb(main):005:1*   f.request :auth0 # authorize requests with Auth0 access tokens
irb(main):006:1*   f.adapter :net_http # Use the Net::HTTP adapter
irb(main):007:0> end
=>
#<Faraday::Connection:0x00007f83b0e3eca8
...
irb(main):008:1* HTTP::Auth0.configure do |auth0|
irb(main):009:1*   auth0.domain = 'insert-domain-here'
irb(main):010:1*   auth0.client_id = 'insert-client-id-here'
irb(main):011:1*   auth0.client_secret = 'insert-client-secret-here'
irb(main):012:0> end
=> HTTP::Auth0
irb(main):013:0> response = conn.post("https://staging-01.api.connect.my.firstcircle.ph/graphql")
=>
#<Faraday::Response:0x00007f83b0e99fb8
...
irb(main):014:0> response.env.request_headers['Authorization']
=> "Bearer eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCIsImtpZCI6ImRKbzFsM3owOEo0REUyVWQ3RHJybiJ9.eyJpc3MiOiJodHRwczovL2Rldi1xNGg1dnhnbS5qcC5hdXRoMC5jb20vIiwic3ViIjoiUWVFR292OURSSjNjTnhGOFNZdXkwMUhnM1JlSHRQeDlAY2xpZW50cyIsImF1ZCI6Imh0dHBzOi8vc3RhZ2luZy0wMS5hcGkuY29ubmVjdC5teS5maXJzdGNpcmNsZS5waC9ncmFwaHFsIiwiaWF0IjoxNjQ0MjIxOTc3LCJleHAiOjE2NDQzMDgzNzcsImF6cCI6IlFlRUdvdjlEUkozY054RjhTWXV5MDFIZzNSZUh0UHg5IiwiZ3R5IjoiY2xpZW50LWNyZWRlbnRpYWxzIiwicGVybWlzc2lvbnMiOltdfQ.AOYXJ-8FisWv73ZXL-HVY8XvTL34RxtUvqU1d172Lb3JXdDFFNSvHwUfzq5nCxmfpN4MC7rlkWbhpoXXb7a__oSBJX-eGsu7KQGSR-aJePn92CG4HHpKmActNcDsCH4RkEKwzU7z8vZSq-IxL-lukByQAH41nXYWfxCMScM_TOL7Vlsrfn2VqPNVZc1oiU4p2oa_Je6kDTXom3t-5qJvIMBgqBj6cTfQkRxgd_ao045CdRwnNv5bz0Ypg-D4QL2lbNB2_FJaePM54aKW99qAvNGQjUY7uyqtndvl7HCDRDjDb1BpU5mjUG_nPOTi0D14Pi7NQ98c9VLVXhXppUEH-Q"

```

* [x] This change adds unit test coverage
* [x] This change adds integration test coverage
* [x] This change has been tested on the latest version of Ruby

### Checklist

* [x] All existing and new tests complete without errors
* [x] Rubocop passes on all added/modified files
* [x] All active GitHub checks have passed